### PR TITLE
Add getter for database `configuredForAccess` property

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -53,7 +53,18 @@ class Database extends EasyRdf_Resource
         $name = $this->get('schema:name');
         return $name;
     }
-    
+
+    /**
+     * Get Configured For Access property value
+     *
+     * @return EasyRDF_Literal
+     */
+    function getConfiguredForAccess()
+    {
+        $configuredForAccess = $this->get('discovery:configuredForAccess');
+        return $configuredForAccess;
+    }
+
     /**
      * Get Requires Authentication property value
      *

--- a/tests/database/DatabaseTest.php
+++ b/tests/database/DatabaseTest.php
@@ -50,6 +50,7 @@ class DatabaseTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEmpty($database->getName());
         $this->assertNotEmpty($database->getRequiresAuthentication());
         $this->assertNotEmpty($database->getDescription());
+        $this->assertNotEmpty($database->getConfiguredForAccess());
     }
     
     /**


### PR DESCRIPTION
This came in handy while debugging but only works for objects returned from `Database::find`, as database lists don't include the `configuredForAccess` property. Thoughts?
